### PR TITLE
tmux: add configuration options for split

### DIFF
--- a/autoload/vimspectorpy.vim
+++ b/autoload/vimspectorpy.vim
@@ -11,6 +11,13 @@ if ! exists("g:vimspectorpy#cmd_prefix")
     let g:vimspectorpy#cmd_prefix = ""
 endif
 
+if ! exists("g:vimspectorpy#tmux#split")
+    let g:vimspectorpy#tmux#split = "v"
+endif
+if ! exists("g:vimspectorpy#tmux#size")
+    let g:vimspectorpy#tmux#size = 10
+endif
+
 function! vimspectorpy#warn(msg)
     echohl WarningMsg | echo "vimspectorpy: " . a:msg | echohl None
 endfunction
@@ -46,7 +53,8 @@ function! vimspectorpy#tmux_launcher(cmd, success_cb, failure_cb)
     for f in glob(base_err_file . "/*" ,1 ,1)
         call delete(f)
     endfor
-    let cmd = "tmux split-window -l 10 -d -P -F '#{pane_id}' sh -c '". a:cmd .
+    let cmd = "tmux split-window -l ". g:vimspectorpy#tmux#size ." -" . g:vimspectorpy#tmux#split .
+                \" -d -P -F '#{pane_id}' sh -c '". a:cmd .
                 \" || tmux capture-pane -S - -E - -p -t $TMUX_PANE > " . base_err_file . ".${TMUX_PANE}'"
     let pane = trim(system(cmd))
     if v:shell_error
@@ -188,4 +196,3 @@ endfunction
 " restore compatible option
 let &cpo = s:save_cpo
 unlet s:save_cpo
-

--- a/doc/vimspectorpy.txt
+++ b/doc/vimspectorpy.txt
@@ -1,5 +1,5 @@
 *vimspectorpy.txt*- python default configurations for vimspector
-  
+
 Description~
 
 Being able to simply debug a piece of code with {ipython} or set a breakpoint
@@ -49,8 +49,8 @@ And also add this:
 
 Install and setup:
 >
-  :PlugInstall 
-  :VimspectorpyUpdate 
+  :PlugInstall
+  :VimspectorpyUpdate
 <
 
 Or Manual~
@@ -203,6 +203,24 @@ You could choose 'rxvt' or force 'xterm' using:
 
 >
   let g:vimspectorpy#launcher = "rxvt"
+
+<
+                          *g:vimspectorpy#tmux#size*
+
+Set the size of the split opened, when using the tmux launcher. Default is
+equivalent to
+
+>
+  let g:vimspectorpy#tmux#size = 10
+<
+
+                          *g:vimspectorpy#tmux#split*
+
+Set the orientation of the split opened, when using the tmux launcher. Valid
+options are "v" for vertical and "h" for horizontal. Default is equivalent to
+
+>
+  let g:vimspectorpy#tmux#split = "v"
 <
 
 ==============================================================================


### PR DESCRIPTION
On wider monitors opening the console in a 10 line high vertical split
may not be the best experience. Introduce two options for configure
orientation and size of split when using tmux.
